### PR TITLE
ENH: Resume all processes on SIGUSR1

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,8 @@ pkg_check_modules (GLIB REQUIRED glib-2.0)
 pkg_check_modules (WNCK REQUIRED libwnck-3.0)
 
 add_definitions (-DWNCK_I_KNOW_THIS_IS_UNSTABLE
-                 -D_POSIX_SOURCE)
+                 -D_POSIX_SOURCE
+                 -D_DEFAULT_SOURCE)
 
 add_compile_options (${GLIB_CFLAGS} ${WNCK_CFLAGS})
 

--- a/src/xsuspender.h
+++ b/src/xsuspender.h
@@ -38,6 +38,7 @@ gboolean xsus_signal_continue (WindowEntry *entry);
 void     xsus_window_entry_enqueue (WindowEntry *entry, unsigned delay);
 void     xsus_window_suspend (WnckWindow *window);
 void     xsus_window_resume (WnckWindow *window);
+void     xsus_resume_all ();
 int      xsus_init ();
 void     xsus_exit ();
 


### PR DESCRIPTION
Fixes https://github.com/kernc/xsuspender/issues/10.

Additionally, define `_DEFAULT_SOURCE` to adhere to BSD signal semantics. See manual _signal(2)_ § _Portabilty_ for info.