### PR TITLE
Add Solus dependencies instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,14 @@ Install binary package for your GNU/Linux distribution:
 
 ```bash
 # Install build dependencies, namely GLib and Libwnck
+#Debian
 sudo apt install libglib2.0-dev \
                  libwnck-3-dev  \
                  make cmake gcc pkg-config
+#Solus
+sudo eopkg install glib2-devel \
+                   libwnck-devel \
+                   make cmake gcc pkg-config
 ```
 
 ```bash


### PR DESCRIPTION
Discovered your work via this GNU/Linuxuprising article. https://www.linuxuprising.com/2020/10/auto-suspend-inactive-x11-applications.html  
Decided to make other users, don’t have to search through dependencies hell to know how those dependencies are named on Solus.