### PR TITLE
Use unused symbol mystdout

### DIFF
--- a/src/exec.c
+++ b/src/exec.c
@@ -12,15 +12,15 @@ static inline
 int
 execute (char **argv,
          char **envp,
-         char **stdout)
+         char **mystdout)
 {
     g_autoptr (GError) err = NULL;
     gint exit_status = -1;
     GSpawnFlags flags = G_SPAWN_STDERR_TO_DEV_NULL |
-                        (stdout ? G_SPAWN_DEFAULT : G_SPAWN_STDOUT_TO_DEV_NULL);
+                        (mystdout ? G_SPAWN_DEFAULT : G_SPAWN_STDOUT_TO_DEV_NULL);
 
     g_spawn_sync (NULL, argv, envp, flags | G_SPAWN_SEARCH_PATH,
-                  NULL, NULL, stdout, NULL, &exit_status, &err);
+                  NULL, NULL, mystdout, NULL, &exit_status, &err);
     if (err)
         g_warning ("Unexpected subprocess execution error: %s", err->message);
 

--- a/src/exec.c
+++ b/src/exec.c
@@ -12,15 +12,15 @@ static inline
 int
 execute (char **argv,
          char **envp,
-         char **mystdout)
+         char **standard_output)
 {
     g_autoptr (GError) err = NULL;
     gint exit_status = -1;
     GSpawnFlags flags = G_SPAWN_STDERR_TO_DEV_NULL |
-                        (mystdout ? G_SPAWN_DEFAULT : G_SPAWN_STDOUT_TO_DEV_NULL);
+                        (standard_output ? G_SPAWN_DEFAULT : G_SPAWN_STDOUT_TO_DEV_NULL);
 
     g_spawn_sync (NULL, argv, envp, flags | G_SPAWN_SEARCH_PATH,
-                  NULL, NULL, mystdout, NULL, &exit_status, &err);
+                  NULL, NULL, standard_output, NULL, &exit_status, &err);
     if (err)
         g_warning ("Unexpected subprocess execution error: %s", err->message);
 


### PR DESCRIPTION
On openbsd stdout is defined in stdio.h as `#define stdout  (&__sF[1])`. So the code won't comple as g_spawn_sync in exec.h expects stdout to be a char** but on openbsd its file*. This patches solves by renaming stdout to mystdout. Sorry for the uninspired name.

Cheers, Mario